### PR TITLE
Add decode_tx method

### DIFF
--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -42,6 +42,13 @@ namespace serial_bridge
 {
 	using namespace std;
 	using namespace cryptonote;
+
+	struct Utxo {
+		string tx_id;
+		uint8_t vout;
+		string amount;
+	};
+
 	//
 	// Bridging Functions - these take and return JSON strings
 	string send_step1__prepare_params_for_get_decoys(const string &args_string);
@@ -75,6 +82,8 @@ namespace serial_bridge
 	string decodeRct(const string &args_string);
 	string decodeRctSimple(const string &args_string);
 	string encrypt_payment_id(const string &args_string);
+
+	string decode_tx(const string &args_string);
 }
 
 #endif /* serial_bridge_index_hpp */

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -47,6 +47,7 @@ namespace serial_bridge
 		string tx_id;
 		uint8_t vout;
 		string amount;
+		string key_image;
 	};
 
 	//

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -35,6 +35,8 @@
 //
 #include <string>
 #include "cryptonote_config.h"
+#include "crypto/crypto.h"
+#include "ringct/rctTypes.h"
 //
 // See serial_bridge_utils.hpp
 //
@@ -42,6 +44,20 @@ namespace serial_bridge
 {
 	using namespace std;
 	using namespace cryptonote;
+
+	struct Output {
+		uint8_t index;
+		crypto::public_key pub;
+		string amount;
+	};
+
+	struct Transaction {
+		string id;
+		crypto::public_key pub;
+		uint8_t version;
+		rct::rctSig rv;
+		vector<Output> outputs;
+	};
 
 	struct Utxo {
 		string tx_id;
@@ -84,6 +100,7 @@ namespace serial_bridge
 	string decodeRctSimple(const string &args_string);
 	string encrypt_payment_id(const string &args_string);
 
+	vector<Utxo> _decode_tx(Transaction tx, crypto::secret_key sec_view_key, crypto::secret_key sec_spend_key, crypto::public_key pub_spend_key);
 	string decode_tx(const string &args_string);
 }
 


### PR DESCRIPTION
This relates to mobile only.

Currently, we make two native calls for each transaction (assuming it's not ours). It doesn't scale well - for 1000 blocks we might need to do 20 000 native calls from RN. I want to improve that by adding `decode_txs` method that can handle N transactions with just one native call - with that we should be able to reduce the number of native calls.

This PR adds `decode_tx` and `_decode_tx` methods.
Next PR will add `decode_txs` method that makes use of `_decode_tx` to process multiple transactions at once.

react-native-fast-crypto needs some build tweaks to handle those changes: https://github.com/ExodusMovement/react-native-fast-crypto/pull/7/files

Tested:
valid utxos are returned for each transaction:
![image](https://user-images.githubusercontent.com/1968722/66209144-08a5d480-e6b7-11e9-8b73-cd7d0adc83bd.png)

