### PR TITLE
feat: add subaddresses support

### DIFF
--- a/src/monero_send_routine.cpp
+++ b/src/monero_send_routine.cpp
@@ -389,6 +389,7 @@ void _reenterable_construct_and_send_tx(
 			args.fee_per_b,
 			args.fee_quantization_mask,
 			*(parsed_res.mix_outs),
+			200,
 			std::move(use_fork_rules),
 			args.unlock_time,
 			args.nettype

--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -366,6 +366,7 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 	uint64_t fee_per_b, // per v8
 	uint64_t fee_quantization_mask,
 	vector<RandomAmountOutputs> &mix_outs, // cannot be const due to convenience__create_transaction's mutability requirement
+	uint32_t subaddresses_count,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	uint64_t unlock_time, // or 0
 	cryptonote::network_type nettype
@@ -380,6 +381,7 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 		to_address_string, payment_id_string,
 		final_total_wo_fee, change_amount, fee_amount,
 		using_outs, mix_outs,
+		subaddresses_count,
 		use_fork_rules_fn,
 		unlock_time,
 		nettype // TODO: move to after from_address_string
@@ -686,6 +688,7 @@ void monero_transfer_utils::convenience__create_transaction(
 	uint64_t fee_amount,
 	const vector<SpendableOutput> &outputs,
 	vector<RandomAmountOutputs> &mix_outs,
+	uint32_t subaddresses_count,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	uint64_t unlock_time,
 	network_type nettype
@@ -750,7 +753,7 @@ void monero_transfer_utils::convenience__create_transaction(
 
 	std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
 	cryptonote::subaddress_index index = {0, 0};
-	serial_bridge::expand_subaddresses(account_keys, subaddresses, index, 200);
+	serial_bridge::expand_subaddresses(account_keys, subaddresses, index, subaddresses_count);
 
 	//
 	TransactionConstruction_RetVals actualCall_retVals;

--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -36,6 +36,7 @@
 #include "string_tools.h"
 #include "monero_paymentID_utils.hpp"
 #include "monero_key_image_utils.hpp"
+#include "serial_bridge_index.hpp"
 //
 using namespace std;
 using namespace crypto;
@@ -745,10 +746,12 @@ void monero_transfer_utils::convenience__create_transaction(
 		}
 		payment_id_seen = true;
 	}
-	//
-	uint32_t subaddr_account_idx = 0;
+	uint32_t subaddr_account_idx = 0; // unused
+
 	std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
-	subaddresses[account_keys.m_account_address.m_spend_public_key] = {0,0};
+	cryptonote::subaddress_index index = {0, 0};
+	serial_bridge::expand_subaddresses(account_keys, subaddresses, index, 200);
+
 	//
 	TransactionConstruction_RetVals actualCall_retVals;
 	create_transaction(

--- a/src/monero_transfer_utils.hpp
+++ b/src/monero_transfer_utils.hpp
@@ -229,6 +229,7 @@ namespace monero_transfer_utils
 		uint64_t fee_per_b, // per v8
 		uint64_t fee_quantization_mask,
 		vector<RandomAmountOutputs> &mix_outs, // it gets sorted
+		uint32_t subaddresses_count,
 		use_fork_rules_fn_type use_fork_rules_fn,
 		uint64_t unlock_time, // or 0
 		cryptonote::network_type nettype
@@ -260,6 +261,7 @@ namespace monero_transfer_utils
 		uint64_t fee_amount,
 		const vector<SpendableOutput> &outputs,
 		vector<RandomAmountOutputs> &mix_outs, // get sorted
+		uint32_t subaddresses_count,
 		use_fork_rules_fn_type use_fork_rules_fn,
 		uint64_t unlock_time							= 0, // or 0
 		network_type nettype 							= MAINNET

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -615,10 +615,6 @@ boost::property_tree::ptree serial_bridge::pruned_block_to_json(const PrunedBloc
 	return block_tree;
 }
 
-bool serial_bridge::keys_equal(crypto::public_key a, crypto::public_key b)
-{
-	return equal(a.data, a.data + 32, b.data);
-}
 string serial_bridge::decode_amount(int version, crypto::key_derivation derivation, rct::rctSig rv, std::string amount, int index)
 {
 	if (version == 1) {

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -1272,6 +1272,7 @@ string serial_bridge::send_step2__try_create_transaction(const string &args_stri
 		stoull(json_root.get<string>("fee_per_b")),
 		stoull(json_root.get<string>("fee_mask")),
 		mix_outs,
+		json_root.get<uint32_t>("subaddresses"),
 		monero_fork_rules::make_use_fork_rules_fn(fork_version),
 		stoull(json_root.get<string>("unlock_time")),
 		nettype_from_string(json_root.get<string>("nettype_string"))

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -576,6 +576,8 @@ boost::property_tree::ptree serial_bridge::utxos_to_json(std::vector<Utxo> utxos
 		out_ptree.put("vout", utxo.vout);
 		out_ptree.put("amount", utxo.amount);
 		out_ptree.put("key_image", utxo.key_image);
+		out_ptree.put("index_major", utxo.index.major);
+		out_ptree.put("index_minor", utxo.index.minor);
 
 		if (native) {
 			out_ptree.put("pub", epee::string_tools::pod_to_hex(utxo.pub));
@@ -673,6 +675,7 @@ std::vector<Utxo> serial_bridge::extract_utxos_from_tx(BridgeTransaction tx, cry
 
 		Utxo utxo;
 		utxo.tx_id = tx.id;
+		utxo.index = (*subaddr_recv_info).index;
 		utxo.vout = output.index;
 		utxo.amount = serial_bridge::decode_amount(tx.version, derivation, tx.rv, output.amount, output.index);
 		utxo.tx_pub = tx.pub;

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -112,11 +112,16 @@ namespace serial_bridge
 		std::vector<BridgeTransaction> txs;
 	};
 
+	struct Result {
+		uint32_t subaddresses;
+		std::vector<BridgeTransaction> txs;
+	};
+
 	struct NativeResponse {
 		std::string error;
 		uint64_t current_height;
 		uint64_t end_height = 0;
-		std::map<std::string, std::vector<BridgeTransaction>> txs_by_wallet_account;
+		std::map<std::string, Result> results_by_wallet_account;
 		uint64_t latest;
 		uint64_t oldest;
 		uint64_t size;

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -37,6 +37,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "cryptonote_config.h"
+#include "cryptonote_basic/account.h"
 #include "cryptonote_basic/tx_extra.h"
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
@@ -98,9 +99,7 @@ namespace serial_bridge
 	};
 
 	struct WalletAccountParams {
-		crypto::secret_key sec_view_key;
-		crypto::secret_key sec_spend_key = crypto::null_skey;
-		crypto::public_key pub_spend_key;
+		cryptonote::account_keys account_keys;
 		bool has_send_txs = false;
 		std::map<std::string, bool> gki;
 		std::map<std::string, bool> send_txs;
@@ -139,7 +138,7 @@ namespace serial_bridge
 	boost::property_tree::ptree utxos_to_json(std::vector<Utxo> utxos, bool native = false);
 	boost::property_tree::ptree pruned_block_to_json(const PrunedBlock &pruned_block);
 	std::string decode_amount(int version, crypto::key_derivation derivation, rct::rctSig rv, std::string amount, int index);
-	std::vector<Utxo> extract_utxos_from_tx(BridgeTransaction tx, crypto::secret_key sec_view_key, crypto::secret_key sec_spend_key, crypto::public_key pub_spend_key);
+	std::vector<Utxo> extract_utxos_from_tx(BridgeTransaction tx, cryptonote::account_keys account_keys);
 
 	//
 	// Bridging Functions - these take and return JSON strings

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -76,6 +76,7 @@ namespace serial_bridge
 		uint64_t block_height;
 		rct::rctSig rv;
 		crypto::public_key pub;
+		std::vector<crypto::public_key> additional_pubs;
 		crypto::hash payment_id = crypto::null_hash;
 		crypto::hash8 payment_id8 = crypto::null_hash8;
 		rct::xmr_amount fee_amount = 0;
@@ -126,6 +127,7 @@ namespace serial_bridge
 	//
 	// Helper Functions
 	crypto::public_key get_extra_pub_key(const std::vector<cryptonote::tx_extra_field> &fields);
+	std::vector<crypto::public_key> get_extra_additional_tx_pub_keys(const std::vector<cryptonote::tx_extra_field> &fields);
 	std::string get_extra_nonce(const std::vector<cryptonote::tx_extra_field> &fields);
 	std::vector<crypto::key_image> get_inputs(const cryptonote::transaction &tx, const BridgeTransaction &bridge_tx, std::map<std::string, bool> &gki);
 	std::vector<crypto::key_image> get_inputs_with_send_txs(const cryptonote::transaction &tx, const BridgeTransaction &bridge_tx, std::map<std::string, bool> &send_txs);

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -41,6 +41,9 @@
 #include "cryptonote_basic/tx_extra.h"
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
+
+#define SUBADDRESS_LOOKAHEAD_MINOR 200
+
 //
 // See serial_bridge_utils.hpp
 //
@@ -100,6 +103,7 @@ namespace serial_bridge
 
 	struct WalletAccountParams {
 		cryptonote::account_keys account_keys;
+		std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
 		bool has_send_txs = false;
 		std::map<std::string, bool> gki;
 		std::map<std::string, bool> send_txs;
@@ -138,7 +142,10 @@ namespace serial_bridge
 	boost::property_tree::ptree utxos_to_json(std::vector<Utxo> utxos, bool native = false);
 	boost::property_tree::ptree pruned_block_to_json(const PrunedBlock &pruned_block);
 	std::string decode_amount(int version, crypto::key_derivation derivation, rct::rctSig rv, std::string amount, int index);
-	std::vector<Utxo> extract_utxos_from_tx(BridgeTransaction tx, cryptonote::account_keys account_keys);
+	std::vector<Utxo> extract_utxos_from_tx(BridgeTransaction tx, cryptonote::account_keys account_keys, std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses);
+
+	void expand_subaddresses(cryptonote::account_keys account_keys, std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses, const cryptonote::subaddress_index& index, uint32_t lookahead = SUBADDRESS_LOOKAHEAD_MINOR);
+	uint32_t get_subaddress_clamped_sum(uint32_t idx, uint32_t extra);
 
 	//
 	// Bridging Functions - these take and return JSON strings

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -38,6 +38,7 @@
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "cryptonote_config.h"
 #include "cryptonote_basic/account.h"
+#include "cryptonote_basic/subaddress_index.h"
 #include "cryptonote_basic/tx_extra.h"
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
@@ -60,6 +61,7 @@ namespace serial_bridge
 
 	struct UtxoBase {
 		string tx_id;
+		cryptonote::subaddress_index index;
 		uint8_t vout;
 		string amount;
 		string key_image;

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -138,7 +138,6 @@ namespace serial_bridge
 	boost::property_tree::ptree inputs_to_json(std::vector<crypto::key_image> inputs);
 	boost::property_tree::ptree utxos_to_json(std::vector<Utxo> utxos, bool native = false);
 	boost::property_tree::ptree pruned_block_to_json(const PrunedBlock &pruned_block);
-	bool keys_equal(crypto::public_key a, crypto::public_key b);
 	std::string decode_amount(int version, crypto::key_derivation derivation, rct::rctSig rv, std::string amount, int index);
 	std::vector<Utxo> extract_utxos_from_tx(BridgeTransaction tx, crypto::secret_key sec_view_key, crypto::secret_key sec_spend_key, crypto::public_key pub_spend_key);
 


### PR DESCRIPTION
- [x] Subaddresses cache (configurable + expanding).
- [x] Sending support (TODO: configurable)
- [x] Receive support (cache, new key images).
- [ ] ~UTXO selection - prefer same subaddress~ is handled in JS. 