### PR TITLE
fix: calculate additional deriviations

### DIFF
--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -670,7 +670,7 @@ std::vector<Utxo> serial_bridge::extract_utxos_from_tx(BridgeTransaction tx, cry
 	for (const auto& pub : tx.additional_pubs) {
 		crypto::key_derivation additional_derivation = AUTO_VAL_INIT(additional_derivation);
 
-		if (!crypto::generate_key_derivation(pub, account_keys.m_view_secret_key, derivation)) {
+		if (!crypto::generate_key_derivation(pub, account_keys.m_view_secret_key, additional_derivation)) {
 			return utxos;
 		}
 


### PR DESCRIPTION
Additional deriviations are not needed for processing, but because of a typo if transactions had `additional_pubs` global `derivation` was overwritten by `additional_derivation`. This caused multioutput (2+) transactions to be skipped.