### PR TITLE
fix: use out-specific pub to decode amount

### DIFF
--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -686,7 +686,7 @@ std::vector<Utxo> serial_bridge::extract_utxos_from_tx(BridgeTransaction tx, cry
 		utxo.tx_id = tx.id;
 		utxo.index = subaddr_recv_info->index;
 		utxo.vout = output.index;
-		utxo.amount = serial_bridge::decode_amount(tx.version, derivation, tx.rv, output.amount, output.index);
+		utxo.amount = serial_bridge::decode_amount(tx.version, subaddr_recv_info->derivation, tx.rv, output.amount, output.index);
 		utxo.tx_pub = tx.pub;
 		utxo.pub = output.pub;
 		utxo.rv = serial_bridge::build_rct(tx.rv, output.index);

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -634,20 +634,16 @@ string serial_bridge::decode_amount(int version, crypto::key_derivation derivati
 	if (version == 1) {
 		return amount;
 	} else if (version == 2) {
-		rct::key sk;
-		crypto::ec_scalar scalar = AUTO_VAL_INIT(scalar);
-		crypto::derivation_to_scalar(derivation, index, scalar);
-
-		string sk_str = epee::string_tools::pod_to_hex(scalar);
-		epee::string_tools::hex_to_pod(sk_str, sk);
+		crypto::secret_key scalar;
+		hw::get_device("default").derivation_to_scalar(derivation, index, scalar);
 
 		rct::key mask;
 		rct::xmr_amount decoded_amount;
 
 		if (rv.type == rct::RCTTypeFull) {
-			decoded_amount = rct::decodeRct(rv, sk, index, mask, hw::get_device("default"));
-		} else if (rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof || rv.type == rct::RCTTypeBulletproof2 || rv.type == rct::RCTTypeBulletproof2 || rv.type == rct::RCTTypeCLSAG) {
-			decoded_amount = rct::decodeRctSimple(rv, sk, index, mask, hw::get_device("default"));
+			decoded_amount = rct::decodeRct(rv, rct::sk2rct(scalar), index, mask, hw::get_device("default"));
+		} else if (rv.type == rct::RCTTypeSimple || rv.type == rct::RCTTypeBulletproof || rv.type == rct::RCTTypeBulletproof2 || rv.type == rct::RCTTypeCLSAG) {
+			decoded_amount = rct::decodeRctSimple(rv, rct::sk2rct(scalar), index, mask, hw::get_device("default"));
 		}
 
 		ostringstream decoded_amount_ss;


### PR DESCRIPTION
Multi-output transactions that include subaddress destinations should use output specific derivation to process amount.
Without this signature wouldn't match and the processing would be aborted (with a crash).

This transaction type was coming from Bitni.com/ChangeNOW so wallets that exchanged to XMR with that exchange to subaddress directly will be affected.

Added [testcase](https://github.com/ExodusMovement/monero-native-tests/blob/a495c77a8f5d9ec4dc5b1462dbbe8f5b3a6fd5f5/main.cpp#L48-L66) for this issue in tests repo.