### PR TITLE
fix: update transaction creation

### DIFF
--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -142,7 +142,7 @@ bool _rct_hex_to_decrypted_mask(
 	sc_sub(decrypted_mask.bytes,
 		encrypted_mask.bytes,
 		rct::hash_to_scalar(make_key_derivation()).bytes);
-	
+
 	return true;
 }
 bool _verify_sec_key(const crypto::secret_key &secret_key, const crypto::public_key &public_key)
@@ -166,7 +166,7 @@ namespace
 			vec[idx] = std::move(vec.back());
 		}
 		vec.resize(vec.size() - 1);
-		
+
 		return res;
 	}
 	//
@@ -174,7 +174,7 @@ namespace
 	T pop_random_value(std::vector<T>& vec)
 	{
 		CHECK_AND_ASSERT_MES(!vec.empty(), T(), "Vector must be non-empty");
-		
+
 		size_t idx = crypto::rand<size_t>() % vec.size();
 		return pop_index (vec, idx);
 	}
@@ -420,12 +420,12 @@ void monero_transfer_utils::create_transaction(
 	const account_keys& sender_account_keys, // this will reference a particular hw::device
 	const uint32_t subaddr_account_idx,
 	const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses,
-	const address_parse_info &to_addr, 
+	const address_parse_info &to_addr,
 	uint64_t sending_amount,
 	uint64_t change_amount,
 	uint64_t fee_amount,
 	const vector<SpendableOutput> &outputs,
-	vector<RandomAmountOutputs> &mix_outs, 
+	vector<RandomAmountOutputs> &mix_outs,
 	const std::vector<uint8_t> &extra,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	uint64_t unlock_time, // or 0
@@ -590,19 +590,27 @@ void monero_transfer_utils::create_transaction(
 		//
 		src.rct = outputs[out_index].rct != boost::none && (*(outputs[out_index].rct)).empty() == false;
 		if (src.rct) {
-			rct::key decrypted_mask;
-			bool r = _rct_hex_to_decrypted_mask(
-				*(outputs[out_index].rct),
-				sender_account_keys.m_view_secret_key,
-				tx_pub_key,
-				internal_output_index,
-				decrypted_mask
-			);
-			if (!r) {
-				retVals.errCode = cantGetDecryptedMaskFromRCTHex;
-				return;
+			if (!outputs[out_index].mask.empty()) {
+				if (!string_tools::hex_to_pod(outputs[out_index].mask, src.mask)) {
+					retVals.errCode = mixRCTOutsMissingCommit;
+					return;
+				}
+			} else {
+				rct::key decrypted_mask;
+				bool r = _rct_hex_to_decrypted_mask(
+					*(outputs[out_index].rct),
+					sender_account_keys.m_view_secret_key,
+					tx_pub_key,
+					internal_output_index,
+					decrypted_mask
+				);
+				if (!r) {
+					retVals.errCode = cantGetDecryptedMaskFromRCTHex;
+					return;
+				}
+				src.mask = decrypted_mask;
 			}
-			src.mask = decrypted_mask;
+
 //			rct::key calculated_commit = rct::commit(outputs[out_index].amount, decrypted_mask);
 //			rct::key parsed_commit;
 //			_rct_hex_to_rct_commit(*(outputs[out_index].rct), parsed_commit);
@@ -810,6 +818,6 @@ void monero_transfer_utils::convenience__create_transaction(
 	//
 //	cout << "out 0: " << string_tools::pod_to_hex(boost::get<txout_to_key>((*(actualCall_retVals.tx)).vout[0].target).key) << endl;
 //	cout << "out 1: " << string_tools::pod_to_hex(boost::get<txout_to_key>((*(actualCall_retVals.tx)).vout[1].target).key) << endl;
-	//	
+	//
 	retVals.txBlob_byteLength = txBlob_byteLength;
 }

--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -572,6 +572,17 @@ void monero_transfer_utils::create_transaction(
 		src.real_out_tx_key = tx_pub_key;
 		//
 		src.real_out_additional_tx_keys = get_additional_tx_pub_keys_from_extra(extra);
+
+		for (const auto& additional_pub_str : outputs[out_index].additional_tx_pubs) {
+			crypto::public_key additional_pub;
+			if (!epee::string_tools::hex_to_pod(additional_pub_str, additional_pub)) {
+				retVals.errCode = givenAnInvalidPubKey;
+				return;
+			}
+
+			src.real_out_additional_tx_keys.push_back(additional_pub);
+		}
+
 		//
 		src.real_output = real_output_index;
 		uint64_t internal_output_index = outputs[out_index].index;

--- a/src/monero_transfer_utils.hpp
+++ b/src/monero_transfer_utils.hpp
@@ -66,6 +66,7 @@ namespace monero_transfer_utils
 		uint64_t index;
 		string tx_pub_key;
 		std::vector<string> additional_tx_pubs;
+		string mask;
 	};
 	struct RandomAmountOutput
 	{
@@ -159,7 +160,7 @@ namespace monero_transfer_utils
 		}
 	}
 	//
-	// See monero_send_routine for actual app-lvl interface used by lightwallets 
+	// See monero_send_routine for actual app-lvl interface used by lightwallets
 	//
 	//
 	// Send_Step* functions procedure for integrators:

--- a/src/monero_transfer_utils.hpp
+++ b/src/monero_transfer_utils.hpp
@@ -65,6 +65,7 @@ namespace monero_transfer_utils
 		uint64_t global_index;
 		uint64_t index;
 		string tx_pub_key;
+		std::vector<string> additional_tx_pubs;
 	};
 	struct RandomAmountOutput
 	{

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -305,6 +305,16 @@ std::string serial_bridge::extract_data_from_blocks_response_str(const char *buf
 			tx_tree.put("timestamp", tx.timestamp);
 			tx_tree.put("height", tx.block_height);
 			tx_tree.put("pub", epee::string_tools::pod_to_hex(tx.pub));
+
+			boost::property_tree::ptree additional_pubs_tree;
+			for (const auto& pub : tx.additional_pubs) {
+				boost::property_tree::ptree value;
+				value.put("", epee::string_tools::pod_to_hex(pub));
+
+				additional_pubs_tree.push_back(std::make_pair("", value));
+			}
+			tx_tree.add_child("additional_pubs", additional_pubs_tree);
+
 			tx_tree.put("fee", tx.fee_amount);
 
 			if (tx.payment_id8 != crypto::null_hash8) {

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -1299,15 +1299,12 @@ string serial_bridge::send_step1__prepare_params_for_get_decoys(const string &ar
 	return ret_json_from_root(root);
 }
 
-CreateTxResponse serial_bridge::send_step2__try_create_transaction_raw(const string &args_string)
+string serial_bridge::send_step2__try_create_transaction(const string &args_string)
 {
-	CreateTxResponse response;
-
 	boost::property_tree::ptree json_root;
 	if (!parsed_json_root(args_string, json_root)) {
 		// it will already have thrown an exception
-		response.error = error_ret_json_from_message("Invalid JSON");
-		return response;
+		return error_ret_json_from_message("Invalid JSON");
 	}
 	//
 	vector<SpendableOutput> using_outs;
@@ -1356,9 +1353,9 @@ CreateTxResponse serial_bridge::send_step2__try_create_transaction_raw(const str
 	if (optl__fork_version_string != none) {
 		fork_version = stoul(*optl__fork_version_string);
 	}
-
+	Send_Step2_RetVals retVals;
 	monero_transfer_utils::send_step2__try_create_transaction(
-		response.retVals,
+		retVals,
 		//
 		json_root.get<string>("from_address_string"),
 		json_root.get<string>("sec_viewKey_string"),
@@ -1379,16 +1376,6 @@ CreateTxResponse serial_bridge::send_step2__try_create_transaction_raw(const str
 		nettype_from_string(json_root.get<string>("nettype_string"))
 	);
 
-	return response;
-}
-
-string serial_bridge::send_step2__try_create_transaction(const string &args_string)
-{
-	auto response = serial_bridge::send_step2__try_create_transaction_raw(args_string);
-
-	if (!response.error.empty()) return response.error;
-
-	auto retVals = response.retVals;
 	boost::property_tree::ptree root;
 	if (retVals.errCode != noError) {
 		root.put(ret_json_key__any__err_code(), retVals.errCode);

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -1314,6 +1314,7 @@ string serial_bridge::send_step2__try_create_transaction(const string &args_stri
 		SpendableOutput out{};
 		out.amount = stoull(output_desc.second.get<string>("amount"));
 		out.public_key = output_desc.second.get<string>("public_key");
+		out.mask = output_desc.second.get<string>("mask");
 		out.rct = output_desc.second.get_optional<string>("rct");
 		if (out.rct != none && (*out.rct).empty() == true) {
 			out.rct = none; // send to 'none' if empty str for safety

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -65,6 +65,7 @@ namespace serial_bridge
 		uint8_t vout;
 		string amount;
 		string key_image;
+		rct::key mask;
 	};
 
 	struct Utxo: public UtxoBase {
@@ -162,7 +163,7 @@ namespace serial_bridge
 	boost::property_tree::ptree inputs_to_json(std::vector<crypto::key_image> inputs);
 	boost::property_tree::ptree utxos_to_json(std::vector<Utxo> utxos, bool native = false);
 	boost::property_tree::ptree pruned_block_to_json(const PrunedBlock &pruned_block);
-	std::string decode_amount(int version, crypto::key_derivation derivation, rct::rctSig rv, std::string amount, int index);
+	std::string decode_amount(int version, crypto::key_derivation derivation, rct::rctSig rv, std::string amount, int index, rct::key& mask);
 	std::vector<Utxo> extract_utxos_from_tx(BridgeTransaction tx, cryptonote::account_keys account_keys, std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses);
 
 	ExtractUtxosResponse extract_utxos_raw(const string &args_string);

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -43,8 +43,6 @@
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
 
-#include "monero_transfer_utils.hpp"
-
 #define SUBADDRESS_LOOKAHEAD_MINOR 200
 
 //
@@ -143,11 +141,6 @@ namespace serial_bridge
 		std::map<std::string, ExtractUtxosResult> results_by_wallet_account;
 	};
 
-	struct CreateTxResponse {
-		std::string error;
-		monero_transfer_utils::Send_Step2_RetVals retVals;
-	};
-
 	//
 	// HTTP helpers
 	const char *create_blocks_request(int height, size_t *length);
@@ -173,7 +166,6 @@ namespace serial_bridge
 	std::vector<Utxo> extract_utxos_from_tx(BridgeTransaction tx, cryptonote::account_keys account_keys, std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses);
 
 	ExtractUtxosResponse extract_utxos_raw(const string &args_string);
-	CreateTxResponse send_step2__try_create_transaction_raw(const string &args_string);
 
 	void expand_subaddresses(cryptonote::account_keys account_keys, std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses, const cryptonote::subaddress_index& index, uint32_t lookahead = SUBADDRESS_LOOKAHEAD_MINOR);
 	uint32_t get_subaddress_clamped_sum(uint32_t idx, uint32_t extra);

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -43,6 +43,8 @@
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
 
+#include "monero_transfer_utils.hpp"
+
 #define SUBADDRESS_LOOKAHEAD_MINOR 200
 
 //
@@ -141,6 +143,11 @@ namespace serial_bridge
 		std::map<std::string, ExtractUtxosResult> results_by_wallet_account;
 	};
 
+	struct CreateTxResponse {
+		std::string error;
+		monero_transfer_utils::Send_Step2_RetVals retVals;
+	};
+
 	//
 	// HTTP helpers
 	const char *create_blocks_request(int height, size_t *length);
@@ -166,6 +173,7 @@ namespace serial_bridge
 	std::vector<Utxo> extract_utxos_from_tx(BridgeTransaction tx, cryptonote::account_keys account_keys, std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses);
 
 	ExtractUtxosResponse extract_utxos_raw(const string &args_string);
+	CreateTxResponse send_step2__try_create_transaction_raw(const string &args_string);
 
 	void expand_subaddresses(cryptonote::account_keys account_keys, std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses, const cryptonote::subaddress_index& index, uint32_t lookahead = SUBADDRESS_LOOKAHEAD_MINOR);
 	uint32_t get_subaddress_clamped_sum(uint32_t idx, uint32_t extra);


### PR DESCRIPTION
This adds support for spending UTXOs from multioutput transactions from [there](https://github.com/ExodusMovement/mymonero-core-cpp/pull/25).