### PR TITLE
fix: Missed expand the subaddress's public keys list when sending XMR to sub-address

### DIFF
--- a/src/monero_send_routine.cpp
+++ b/src/monero_send_routine.cpp
@@ -426,7 +426,7 @@ void _reenterable_construct_and_send_tx(
 			args.fee_per_b,
 			args.fee_quantization_mask,
 			tie_outs_to_mix_outs_retVals.mix_outs,
-			200,
+			subaddresses_count,
 			std::move(use_fork_rules),
 			args.unlock_time,
 			args.nettype

--- a/src/monero_send_routine.cpp
+++ b/src/monero_send_routine.cpp
@@ -426,6 +426,7 @@ void _reenterable_construct_and_send_tx(
 			args.fee_per_b,
 			args.fee_quantization_mask,
 			tie_outs_to_mix_outs_retVals.mix_outs,
+			200,
 			std::move(use_fork_rules),
 			args.unlock_time,
 			args.nettype

--- a/src/monero_send_routine.hpp
+++ b/src/monero_send_routine.hpp
@@ -53,6 +53,11 @@ namespace monero_send_routine
 	using namespace cryptonote;
 	using namespace monero_transfer_utils;
 	using namespace crypto;
+
+	//
+	// Constants
+	static const uint32_t subaddresses_count = 200;
+	
 	//
 	// Abstracted Send routine
 	// - Accessory types - Callbacks - Data fetch hooks

--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -447,6 +447,7 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 	uint64_t fee_per_b, // per v8
 	uint64_t fee_quantization_mask,
 	vector<RandomAmountOutputs> &mix_outs, // cannot be const due to convenience__create_transaction's mutability requirement
+	uint32_t subaddresses_count,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	uint64_t unlock_time, // or 0
 	cryptonote::network_type nettype
@@ -461,6 +462,7 @@ void monero_transfer_utils::send_step2__try_create_transaction(
 		to_address_string, payment_id_string,
 		final_total_wo_fee, change_amount, fee_amount,
 		using_outs, mix_outs,
+		subaddresses_count,
 		use_fork_rules_fn,
 		unlock_time,
 		nettype // TODO: move to after from_address_string
@@ -783,6 +785,7 @@ void monero_transfer_utils::convenience__create_transaction(
 	uint64_t fee_amount,
 	const vector<SpendableOutput> &outputs,
 	vector<RandomAmountOutputs> &mix_outs,
+	uint32_t subaddresses_count,
 	use_fork_rules_fn_type use_fork_rules_fn,
 	uint64_t unlock_time,
 	network_type nettype
@@ -846,7 +849,9 @@ void monero_transfer_utils::convenience__create_transaction(
 	//
 	uint32_t subaddr_account_idx = 0;
 	std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
-	subaddresses[account_keys.m_account_address.m_spend_public_key] = {0,0};
+	cryptonote::subaddress_index index = {0, 0};
+	serial_bridge::expand_subaddresses(account_keys, subaddresses, index, subaddresses_count);
+
 	//
 	TransactionConstruction_RetVals actualCall_retVals;
 	create_transaction(

--- a/src/monero_transfer_utils.hpp
+++ b/src/monero_transfer_utils.hpp
@@ -257,6 +257,7 @@ namespace monero_transfer_utils
 		uint64_t fee_per_b, // per v8
 		uint64_t fee_quantization_mask,
 		vector<RandomAmountOutputs> &mix_outs, // it gets sorted
+		uint32_t subaddresses_count,
 		use_fork_rules_fn_type use_fork_rules_fn,
 		uint64_t unlock_time, // or 0
 		cryptonote::network_type nettype
@@ -288,6 +289,7 @@ namespace monero_transfer_utils
 		uint64_t fee_amount,
 		const vector<SpendableOutput> &outputs,
 		vector<RandomAmountOutputs> &mix_outs, // get sorted
+		uint32_t subaddresses_count,
 		use_fork_rules_fn_type use_fork_rules_fn,
 		uint64_t unlock_time							= 0, // or 0
 		network_type nettype 							= MAINNET

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -124,16 +124,12 @@ NativeResponse serial_bridge::extract_data_from_blocks_response(const char *buff
 
 			for (const auto &send_tx_desc : *send_txs_child) {
 				assert(send_tx_desc.first.empty());
-
 				wallet_account_params.send_txs.insert(std::pair<std::string, bool>(send_tx_desc.second.get_value<std::string>(), true));
 			}
 		}
-		else
-		{
-			for (const auto &image_desc : params_desc.second.get_child("key_images"))
-			{
+		else {
+			for (const auto &image_desc : params_desc.second.get_child("key_images")) {
 				assert(image_desc.first.empty());
-
 				wallet_account_params.gki.insert(std::pair<std::string, bool>(image_desc.second.get_value<std::string>(), true));
 			}
 		}
@@ -279,9 +275,11 @@ NativeResponse serial_bridge::extract_data_from_blocks_response(const char *buff
 	}
 
 	for (const auto &pair : wallet_accounts_params) {
-		auto &result = native_resp.results_by_wallet_account[pair.first];
-
+		Result result;
 		result.subaddresses = pair.second.subaddresses.size();
+		result.txs = pair.second.txs;
+
+		native_resp.results_by_wallet_account.insert(std::make_pair(pair.first, result));
 	}
 
 	native_resp.current_height = resp.current_height;
@@ -311,8 +309,7 @@ std::string serial_bridge::extract_data_from_blocks_response_str(const char *buf
 	boost::property_tree::ptree results_tree;
 	for (const auto &pair : resp.results_by_wallet_account) {
 		boost::property_tree::ptree txs_tree;
-		for (const auto &tx : pair.second.txs)
-		{
+		for (const auto &tx : pair.second.txs) {
 			boost::property_tree::ptree tx_tree;
 
 			tx_tree.put("id", tx.id);

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -1504,6 +1504,7 @@ string serial_bridge::send_step2__try_create_transaction(const string &args_stri
 		stoull(json_root.get<string>("fee_per_b")),
 		stoull(json_root.get<string>("fee_mask")),
 		mix_outs,
+		json_root.get<uint32_t>("subaddresses"),
 		monero_fork_rules::make_use_fork_rules_fn(fork_version),
 		stoull(json_root.get<string>("unlock_time")),
 		nettype_from_string(json_root.get<string>("nettype_string"))


### PR DESCRIPTION
# Summary
For sending to subaddress, the `create_transaction` function is missing from expanding the list of subaddresses and calculating public keys for them. (1) 
This missing caused the mismatch between the derivated public key and the above calculated public keys at [lines](https://github.com/ExodusMovement/monero-core-custom/blob/0c23c8d58c4247bae91c0f62c77fb815f5bb5e08/cryptonote_basic/cryptonote_format_utils.cpp#L866-L869).

Issue:[ Slack thread](https://exodusio.slack.com/archives/C03SSRX5144/p1661722462626369) 

- [x] Tested on my side
- [x] Built successfully on my side