### PR TITLE
fix: revert the wrong code in extract_data_from_blocks_response

### DIFF
--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -274,12 +274,10 @@ NativeResponse serial_bridge::extract_data_from_blocks_response(const char *buff
 #endif
 	}
 
-	for (const auto &pair : wallet_accounts_params) {
-		Result result;
-		result.subaddresses = pair.second.subaddresses.size();
-		result.txs = pair.second.txs;
+	for (const auto& pair : wallet_accounts_params) {
+		auto &result = native_resp.results_by_wallet_account[pair.first];
 
-		native_resp.results_by_wallet_account.insert(std::make_pair(pair.first, result));
+		result.subaddresses = pair.second.subaddresses.size();
 	}
 
 	native_resp.current_height = resp.current_height;


### PR DESCRIPTION
# Summary
I misunderstood Wiktor's [comment](https://github.com/ExodusMovement/mymonero-core-cpp/pull/30#issuecomment-1232766973) and added the [wrong code](https://github.com/ExodusMovement/mymonero-core-cpp/pull/30/commits/f01850be647c8b431c11f2534973cd47b66fd73c) without testing to calculate the subaddresses in the function `extract_data_from_blocks_response`.

I fixed it by reverting the correct newest code. I tested with building binaries file and core-js lib. 
