### PR TITLE
feat: apply view_tag to reduce sync time

### DIFF
--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -523,8 +523,12 @@ BridgeTransaction serial_bridge::json_to_tx(boost::property_tree::ptree tx_desc)
 	BridgeTransaction tx;
 
 	tx.id = tx_desc.get<string>("id");
-	tx.block_height = tx_desc.get<uint64_t>("block_height");
 
+	optional<string> str = tx_desc.get_optional<string>("pub");
+	if (str == none) {
+		throw std::invalid_argument("Missing 'tx_desc.pub'");
+	}
+	
 	if (!epee::string_tools::hex_to_pod(tx_desc.get<string>("pub"), tx.pub)) {
 		throw std::invalid_argument("Invalid 'tx_desc.pub'");
 	}

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -604,8 +604,8 @@ BridgeTransaction serial_bridge::json_to_tx(boost::property_tree::ptree tx_desc)
 		output.amount = output_desc.second.get<string>("amount");
 
 	
-		auto viewTagString = output_desc.second.get<string>("view_tag");
-		if (!viewTagString.empty() && !epee::string_tools::hex_to_pod(viewTagString, output.view_tag)) {
+		auto viewTagString = output_desc.second.get_optional<string>("view_tag");
+		if (viewTagString && !epee::string_tools::hex_to_pod(*viewTagString, output.view_tag)) {
 			throw std::invalid_argument("Invalid 'tx_desc.outputs.view_tag'");
 		}
 

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -610,7 +610,8 @@ BridgeTransaction serial_bridge::json_to_tx(boost::property_tree::ptree tx_desc)
 		}
 
 		output.amount = output_desc.second.get<string>("amount");
-		output.view_tag = output_desc.second.get<string>("view_tag");
+
+		epee::string_tools::hex_to_pod(output_desc.second.get<string>("view_tag"), output.view_tag);
 
 		tx.outputs.push_back(output);
 	}

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -605,7 +605,7 @@ BridgeTransaction serial_bridge::json_to_tx(boost::property_tree::ptree tx_desc)
 
 	
 		auto viewTagString = output_desc.second.get<string>("view_tag");
-		if (viewTagString && !epee::string_tools::hex_to_pod(viewTagString, output.view_tag)) {
+		if (viewTagString != none && !epee::string_tools::hex_to_pod(viewTagString, output.view_tag)) {
 			throw std::invalid_argument("Invalid 'tx_desc.outputs.view_tag'");
 		}
 

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -603,12 +603,13 @@ BridgeTransaction serial_bridge::json_to_tx(boost::property_tree::ptree tx_desc)
 
 		output.amount = output_desc.second.get<string>("amount");
 
-	
+		crypto::view_tag view_tag = crypto::view_tag{};
 		auto viewTagString = output_desc.second.get_optional<string>("view_tag");
-		if (viewTagString && !epee::string_tools::hex_to_pod(*viewTagString, output.view_tag)) {
-			throw std::invalid_argument("Invalid 'tx_desc.outputs.view_tag'");
+		if (viewTagString) {
+			bool r = epee::string_tools::hex_to_pod(std::string(*viewTagString), view_tag);
+			THROW_WALLET_EXCEPTION_IF(!r, error::wallet_internal_error, "Invalid 'tx_desc.outputs.view_tag'");
 		}
-
+		output.view_tag = view_tag;
 		tx.outputs.push_back(output);
 	}
 

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -610,6 +610,7 @@ BridgeTransaction serial_bridge::json_to_tx(boost::property_tree::ptree tx_desc)
 		}
 
 		output.amount = output_desc.second.get<string>("amount");
+		output.view_tag = output_desc.second.get<string>("view_tag");
 
 		tx.outputs.push_back(output);
 	}
@@ -726,8 +727,8 @@ std::vector<Utxo> serial_bridge::extract_utxos_from_tx(BridgeTransaction tx, cry
 		additional_derivations.push_back(additional_derivation);
 	}
 
-	BOOST_FOREACH (auto &output, tx.outputs) {
-		boost::optional<subaddress_receive_info> subaddr_recv_info = is_out_to_acc_precomp(subaddresses, output.pub, derivation, additional_derivations, output.index, hwdev);
+	BOOST_FOREACH (Output &output, tx.outputs) {
+		boost::optional<subaddress_receive_info> subaddr_recv_info = is_out_to_acc_precomp(subaddresses, output.pub, derivation, additional_derivations, output.index, hwdev, output.view_tag);
 		if (!subaddr_recv_info) continue;
 
 		Utxo utxo;

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -818,8 +818,6 @@ ExtractUtxosResponse serial_bridge::extract_utxos_raw(const string &args_string)
 	{
 		const BridgeTransaction &tx;
 	};
- 	std::vector<geniod_params> geniods;
-	geniods.reserve(txes.size());
 
 	auto geniod = [&](const BridgeTransaction &tx) {
 		for (auto& pair : wallet_accounts_params) {
@@ -834,29 +832,6 @@ ExtractUtxosResponse serial_bridge::extract_utxos_raw(const string &args_string)
         tpool.submit(&waiter, [&, tx](){ geniod(tx); }, true);
     }
 
-	// View tags significantly speed up the geniod function that determines if an output belongs to the account.
-	// Because the speedup is so large, the overhead from submitting individual geniods to the thread pool eats into
-	// the benefit of executing in parallel. So to maximize the benefit from threads when view tags are enabled,
-	// the wallet starts submitting geniod function calls to the thread pool in batches of size GENIOD_BATCH_SIZE.
-	// if (geniods.size()) {
-	// 	size_t GENIOD_BATCH_SIZE = 100;
-	// 	size_t num_batch_txes = 0;
-	// 	size_t batch_start = 0;
-
-	// 	while (batch_start < geniods.size()) {
-	// 		size_t batch_end = std::min(batch_start + GENIOD_BATCH_SIZE, geniods.size());
-	// 		THROW_WALLET_EXCEPTION_IF(batch_end < batch_start, error::wallet_internal_error, "Thread batch end overflow");
-	// 		tpool.submit(&waiter, [&geniods, &geniod, batch_start, batch_end]() {
-	// 			for (size_t i = batch_start; i < batch_end; ++i) {
-	// 				const geniod_params &gp = geniods[i];
-	// 				geniod(gp.tx);
-	// 			}
-	// 		}, true);
-	// 		num_batch_txes += batch_end - batch_start;
-	// 		batch_start = batch_end;
-	// 	}
-	// 	THROW_WALLET_EXCEPTION_IF(num_batch_txes != geniods.size(), error::wallet_internal_error, "txes batched for thread pool did not reach expected value");
-	// }
 	THROW_WALLET_EXCEPTION_IF(!waiter.wait(), error::wallet_internal_error, "Exception in thread pool");
 
 	for (const auto& pair : wallet_accounts_params) {

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -830,36 +830,37 @@ ExtractUtxosResponse serial_bridge::extract_utxos_raw(const string &args_string)
 		}
 	};
 
-	for (const auto& tx : txes) {
-      if (tx.block_height > 2688888)
-        geniods.push_back(geniod_params{ tx });
-      else
-        tpool.submit(&waiter, [&, tx](){ geniod(tx); }, true);
-    }
+	// for (const auto& tx : txes) {
+    //   if (tx.block_height > 2688888)
+    //     geniods.push_back(geniod_params{ tx });
+    //   else
+    //     tpool.submit(&waiter, [&, tx](){ geniod(tx); }, true);
+    // }
+	tpool.submit(&waiter, [&, tx](){ geniod(tx); }, true);
 
 	// View tags significantly speed up the geniod function that determines if an output belongs to the account.
 	// Because the speedup is so large, the overhead from submitting individual geniods to the thread pool eats into
 	// the benefit of executing in parallel. So to maximize the benefit from threads when view tags are enabled,
 	// the wallet starts submitting geniod function calls to the thread pool in batches of size GENIOD_BATCH_SIZE.
-	if (geniods.size()) {
-		size_t GENIOD_BATCH_SIZE = 100;
-		size_t num_batch_txes = 0;
-		size_t batch_start = 0;
+	// if (geniods.size()) {
+	// 	size_t GENIOD_BATCH_SIZE = 100;
+	// 	size_t num_batch_txes = 0;
+	// 	size_t batch_start = 0;
 
-		while (batch_start < geniods.size()) {
-			size_t batch_end = std::min(batch_start + GENIOD_BATCH_SIZE, geniods.size());
-			THROW_WALLET_EXCEPTION_IF(batch_end < batch_start, error::wallet_internal_error, "Thread batch end overflow");
-			tpool.submit(&waiter, [&geniods, &geniod, batch_start, batch_end]() {
-				for (size_t i = batch_start; i < batch_end; ++i) {
-					const geniod_params &gp = geniods[i];
-					geniod(gp.tx);
-				}
-			}, true);
-			num_batch_txes += batch_end - batch_start;
-			batch_start = batch_end;
-		}
-		THROW_WALLET_EXCEPTION_IF(num_batch_txes != geniods.size(), error::wallet_internal_error, "txes batched for thread pool did not reach expected value");
-	}
+	// 	while (batch_start < geniods.size()) {
+	// 		size_t batch_end = std::min(batch_start + GENIOD_BATCH_SIZE, geniods.size());
+	// 		THROW_WALLET_EXCEPTION_IF(batch_end < batch_start, error::wallet_internal_error, "Thread batch end overflow");
+	// 		tpool.submit(&waiter, [&geniods, &geniod, batch_start, batch_end]() {
+	// 			for (size_t i = batch_start; i < batch_end; ++i) {
+	// 				const geniod_params &gp = geniods[i];
+	// 				geniod(gp.tx);
+	// 			}
+	// 		}, true);
+	// 		num_batch_txes += batch_end - batch_start;
+	// 		batch_start = batch_end;
+	// 	}
+	// 	THROW_WALLET_EXCEPTION_IF(num_batch_txes != geniods.size(), error::wallet_internal_error, "txes batched for thread pool did not reach expected value");
+	// }
 	THROW_WALLET_EXCEPTION_IF(!waiter.wait(), error::wallet_internal_error, "Exception in thread pool");
 
 	for (const auto& pair : wallet_accounts_params) {

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -830,13 +830,9 @@ ExtractUtxosResponse serial_bridge::extract_utxos_raw(const string &args_string)
 		}
 	};
 
-	// for (const auto& tx : txes) {
-    //   if (tx.block_height > 2688888)
-    //     geniods.push_back(geniod_params{ tx });
-    //   else
-    //     tpool.submit(&waiter, [&, tx](){ geniod(tx); }, true);
-    // }
-	tpool.submit(&waiter, [&, tx](){ geniod(tx); }, true);
+	for (const auto& tx : txes) {
+        tpool.submit(&waiter, [&, tx](){ geniod(tx); }, true);
+    }
 
 	// View tags significantly speed up the geniod function that determines if an output belongs to the account.
 	// Because the speedup is so large, the overhead from submitting individual geniods to the thread pool eats into

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -605,7 +605,7 @@ BridgeTransaction serial_bridge::json_to_tx(boost::property_tree::ptree tx_desc)
 
 	
 		auto viewTagString = output_desc.second.get<string>("view_tag");
-		if (viewTagString != none && !epee::string_tools::hex_to_pod(viewTagString, output.view_tag)) {
+		if (!viewTagString.empty() && !epee::string_tools::hex_to_pod(viewTagString, output.view_tag)) {
 			throw std::invalid_argument("Invalid 'tx_desc.outputs.view_tag'");
 		}
 


### PR DESCRIPTION
# Summary
One of the most common complaints around using Monero day-to-day is the time that it can take to sync up a wallet before being able to send Monero. It seems important to speed up scan times. I think we can easily reduce the sync timing ~30-40% with 1 additional byte per output; call it the '[view tag](https://localmonero.co/knowledge/view-tags-reduce-monero-sync-time)’. 

The principle is simple (and has likely been suggested before), make a shared secret between the sender and receiver, hash it, then record the first 1 byte in the chain (the view tag). Recipients calculate the shared secret, hash it, and check if it matches any view tags in the tx. If it does match, then continue checking for owned outputs in the normal way. It will only match about 1/256 of the time, so scan time will be primarily a function of checking view tags.

I did many timing tests and saw the difference between before and after applying view_tag. The duration of sync has been reduced around by around 30 -> 40%.

Depending on [adding the threadpool module in monero-core-custom](https://github.com/ExodusMovement/monero-core-custom/pull/13)

# Screenshots
Here is my test when syncing +30k blocks before and after using view_tag
## Before

<img width="400" alt="Screenshot 2022-11-14 at 00 10 21" src="https://user-images.githubusercontent.com/11265773/201535332-2beccca4-31dd-4fa9-9a75-b3daed047878.png">

## After

<img width="400" alt="Screenshot 2022-11-14 at 00 27 36" src="https://user-images.githubusercontent.com/11265773/201535378-59febdf7-4457-462b-85f1-2f788e137107.png">

