### PR TITLE
feat!: enhance fee estimation + scaling support

### DIFF
--- a/src/monero_fee_utils.hpp
+++ b/src/monero_fee_utils.hpp
@@ -56,17 +56,19 @@ namespace monero_fee_utils
 	uint64_t get_fee_multiplier(uint32_t priority, uint32_t default_priority, int fee_algorithm, use_fork_rules_fn_type use_fork_rules_fn);
 	int get_fee_algorithm(use_fork_rules_fn_type use_fork_rules_fn);
 	uint64_t get_base_fee(uint64_t fee_per_b);
+	uint64_t get_base_fee(uint32_t priority, uint64_t fee_per_b, const std::vector<uint64_t> fees, use_fork_rules_fn_type use_fork_rules_fn);
 	//
-	uint64_t estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, uint64_t base_fee, uint64_t fee_multiplier, uint64_t fee_quantization_mask);
+	uint64_t estimate_fee(bool use_per_byte_fee, bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus, bool use_view_tags, uint64_t base_fee, uint64_t fee_quantization_mask);
+
+	uint64_t calculate_fee_from_weight(uint64_t base_fee, uint64_t weight, uint64_t fee_quantization_mask);
+	uint64_t calculate_fee(bool use_per_byte_fee, const cryptonote::transaction &tx, size_t blob_size, uint64_t base_fee, uint64_t fee_quantization_mask);
+	uint64_t calculate_fee_from_size(uint64_t fee_per_b, size_t bytes);
 	//
-	uint64_t calculate_fee_from_weight(uint64_t base_fee, uint64_t weight, uint64_t fee_multiplier, uint64_t fee_quantization_mask);
-	uint64_t calculate_fee(bool use_per_byte_fee, const cryptonote::transaction &tx, size_t blob_size, uint64_t base_fee, uint64_t fee_multiplier, uint64_t fee_quantization_mask);
-	//
-	/*Added*/ uint64_t calculate_fee_from_size(uint64_t fee_per_b, size_t bytes, uint64_t fee_multiplier);
-	//
-	size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag);
-	uint64_t estimate_tx_weight(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag);
-	size_t estimate_tx_size(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag);
+	
+	size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus, bool use_view_tags);
+	uint64_t estimate_tx_weight(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus, bool use_view_tags);
+	size_t estimate_tx_size(bool use_rct, int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof, bool clsag, bool bulletproof_plus, bool use_view_tags);
+	
 	uint64_t estimated_tx_network_fee( // convenience function for size + calc
 		uint64_t fee_per_b,
 		uint32_t priority, // when priority=0, falls back to monero_fee_utils::default_priority()

--- a/src/monero_send_routine.cpp
+++ b/src/monero_send_routine.cpp
@@ -317,6 +317,7 @@ struct _SendFunds_ConstructAndSendTx_Args
 	uint64_t sending_amount;
 	bool is_sweeping;
 	uint32_t simple_priority;
+	const vector<uint64_t> &fees;
 	const send__get_random_outs_fn_type &get_random_outs_fn;
 	const send__submit_raw_tx_fn_type &submit_raw_tx_fn;
 	const send__status_update_fn_type &status_update_fn;
@@ -422,6 +423,7 @@ void _reenterable_construct_and_send_tx(
 			step1_retVals.change_amount,
 			step1_retVals.using_fee,
 			args.simple_priority,
+			args.fees,
 			step1_retVals.using_outs,
 			args.fee_per_b,
 			args.fee_quantization_mask,
@@ -565,7 +567,7 @@ void monero_send_routine::async__send_funds(Async_SendFunds_Args args)
 		_reenterable_construct_and_send_tx(_SendFunds_ConstructAndSendTx_Args{
 			args.from_address_string, args.sec_viewKey_string, args.sec_spendKey_string,
 			args.to_address_string, args.payment_id_string, usable__sending_amount, args.is_sweeping, args.simple_priority,
-			args.get_random_outs_fn, args.submit_raw_tx_fn, args.status_update_fn, args.error_cb_fn, args.success_cb_fn,
+			args.fees, args.get_random_outs_fn, args.submit_raw_tx_fn, args.status_update_fn, args.error_cb_fn, args.success_cb_fn,
 			args.unlock_time == none ? 0 : *(args.unlock_time),
 			args.nettype == none ? MAINNET : *(args.nettype),
 			//

--- a/src/monero_send_routine.hpp
+++ b/src/monero_send_routine.hpp
@@ -239,6 +239,7 @@ namespace monero_send_routine
 		uint64_t sending_amount;
 		bool is_sweeping;
 		uint32_t simple_priority;
+		vector<uint64_t> fees;
 		send__get_unspent_outs_fn_type get_unspent_outs_fn;
 		send__get_random_outs_fn_type get_random_outs_fn;
 		send__submit_raw_tx_fn_type submit_raw_tx_fn;

--- a/src/monero_transfer_utils.hpp
+++ b/src/monero_transfer_utils.hpp
@@ -253,6 +253,7 @@ namespace monero_transfer_utils
 		uint64_t change_amount,
 		uint64_t fee_amount,
 		uint32_t simple_priority,
+		const vector<uint64_t> &fees,
 		const vector<SpendableOutput> &using_outs,
 		uint64_t fee_per_b, // per v8
 		uint64_t fee_quantization_mask,


### PR DESCRIPTION
# Summary
Enhance the fee estimation with the following:
- Apply scaling fee mechanism instead of fee-multiplier by priority to get the `baseFee`. ([reference](https://github.com/monero-project/monero/blob/8123d945f874548e87d3850b6633f047120ece45/src/wallet/wallet2.cpp#L7926-L7957))
- Fix the tx size estimation
