### PR TITLE
feat: support data in both gzip and json

### DIFF
--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -88,6 +88,66 @@ const char *serial_bridge::create_blocks_request(int height, size_t *length) {
 	return (const char *)arr;
 }
 
+bool serial_bridge::is_gzip_compressed(const char *buffer, size_t length) {
+    return length > 2 && (static_cast<unsigned char>(buffer[0]) == 0x1F) && 
+                          (static_cast<unsigned char>(buffer[1]) == 0x8B);
+}
+
+const char* serial_bridge::decompress(const char *buffer, size_t length) {
+    if (buffer == nullptr || length == 0) {
+        throw std::invalid_argument("Invalid input data");
+    }
+
+    int ret;
+    z_stream strm;
+    static const size_t BUFFER_SIZE = 32768;
+    unsigned char outBuffer[BUFFER_SIZE];
+    std::vector<char> decompressedData;  // Use vector<char> for dynamic storage
+
+    // Initialize the decompression stream
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    strm.opaque = Z_NULL;
+    strm.next_in = Z_NULL;
+    ret = inflateInit2(&strm, (16 + MAX_WBITS));  // MAX_WBITS + 16 for gzip decoding
+    if (ret != Z_OK) {
+        throw std::runtime_error("inflateInit failed while decompressing.");
+    }
+
+    // Set the input data
+    strm.avail_in = length;
+    strm.next_in = reinterpret_cast<Bytef*>(const_cast<char*>(buffer));
+
+    // Decompress until deflate stream ends or end of file
+    do {
+        strm.avail_out = BUFFER_SIZE;
+        strm.next_out = outBuffer;
+        ret = inflate(&strm, Z_NO_FLUSH);
+        switch (ret) {
+            case Z_NEED_DICT:
+            case Z_DATA_ERROR:
+            case Z_MEM_ERROR:
+			case Z_STREAM_ERROR:
+                inflateEnd(&strm);
+                throw std::runtime_error("Decompression error");
+        }
+
+        decompressedData.insert(decompressedData.end(), outBuffer, outBuffer + BUFFER_SIZE - strm.avail_out);
+    } while (strm.avail_out == 0);
+
+    // Clean up the zlib stream
+    inflateEnd(&strm);
+    if (ret != Z_STREAM_END) {
+        throw std::runtime_error("Incomplete decompression: more data was expected");
+    }
+
+    char* result = new char[decompressedData.size() + 1];
+    std::memcpy(result, decompressedData.data(), decompressedData.size());
+    result[decompressedData.size()] = '\0';
+
+    return result;
+}
+
 std::map<std::string, WalletAccountParams> serial_bridge::get_wallet_accounts_params(boost::property_tree::ptree tree) {
     std::map<std::string, WalletAccountParams> wallet_accounts_params;
     for (const auto &params_desc : tree) {
@@ -318,15 +378,35 @@ NativeResponse serial_bridge::extract_data_from_clarity_blocks_response(const ch
 		native_resp.results_by_wallet_account.insert(std::make_pair(pair.first, ExtractTransactionsResult{}));
 	}
 
-	// Convert buffer to string for parsing to JSON
 	boost::property_tree::ptree blocks_json_root;
-    std::string json_string(buffer, length);
-    try {
-        std::stringstream ss(json_string);
-        boost::property_tree::read_json(ss, blocks_json_root);
-    } catch (const std::exception& e) {
-        native_resp.error = std::string("Error processing blocks data from clarity: ") + e.what();
-        return native_resp;
+	if (serial_bridge::is_gzip_compressed(buffer, length)) {
+		const char* decompressed_blocks = nullptr;
+		try {
+			decompressed_blocks = serial_bridge::decompress(buffer, length);
+			if (!parsed_json_root(decompressed_blocks, blocks_json_root)) {
+				native_resp.error = "Invalid blocks JSON";
+				delete[] decompressed_blocks; // Clean up the allocated memory
+				return native_resp;
+			}
+		} catch (const std::exception& e) {
+			native_resp.error = std::string("Error processing blocks data in GZIP from clarity: ") + e.what();
+	
+			// Clean up the allocated memory
+			if (decompressed_blocks) {
+				delete[] decompressed_blocks;
+			}
+			return native_resp;
+		}
+    } else {
+		std::string json_string(buffer, length);
+		json_string = json_string.substr(0, json_string.find('\0'));
+        try {
+			std::stringstream ss(json_string);
+			boost::property_tree::read_json(ss, blocks_json_root);
+		} catch (const std::exception& e) {
+			native_resp.error = std::string("Error processing blocks data in JSON from clarity: ") + e.what();
+			return native_resp;
+		}
     }
 
     for (auto &block_json_root : blocks_json_root) {

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -34,6 +34,8 @@
 #define serial_bridge_index_hpp
 //
 #include <string>
+#include <stdexcept>
+#include <zlib.h>
 #include <boost/property_tree/ptree.hpp>
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "cryptonote_config.h"
@@ -154,6 +156,8 @@ namespace serial_bridge
 	std::string extract_data_from_blocks_response_str(const char *buffer, size_t length, const string &args_string);
     std::string extract_data_from_clarity_blocks_response_str(const char *buffer, size_t length, const string &args_string);
 	std::string get_transaction_pool_hashes_str(const char *buffer, size_t length);
+    const char* decompress(const char *buffer, size_t length);
+	bool is_gzip_compressed(const char *buffer, size_t length);
 
 	//
 	// Helper Functions

--- a/src/serial_bridge_utils.hpp
+++ b/src/serial_bridge_utils.hpp
@@ -38,6 +38,7 @@
 #include <boost/property_tree/json_parser.hpp>
 //
 #include "cryptonote_config.h"
+#include "cryptonote_basic/blobdatatype.h"
 //
 
 namespace serial_bridge_utils


### PR DESCRIPTION
## Summary
Bring the feature to handle blocks data in gzip format to keep the backward compatible on mobile usage. This PR simply brings back the [old decompress function](https://github.com/ExodusMovement/mymonero-core-cpp/pull/37) and adds a condition to detect whether the data is compressed or not.