### PR TITLE
feat: add trezor check_computed_key_image

### DIFF
--- a/src/device_trezor.cpp
+++ b/src/device_trezor.cpp
@@ -1,0 +1,52 @@
+//
+// Created by Danh Vo on 26/3/25.
+//
+
+#include "device_trezor.hpp"
+#include <ringct/rctSigs.h>
+#include "string_tools.h"
+
+#include "tools__ret_vals.hpp"
+
+using namespace std;
+using namespace epee;
+using namespace crypto;
+
+namespace device_trezor{
+    void check_computed_key_image(const crypto::public_key& out_key, const crypto::key_image& ki, const std::string signature, tools::RetVals_base& retVals) {     
+        retVals = {};
+
+        const char* buff = signature.data();
+
+        if (signature.size() < 64) {
+            retVals.did_error = true;
+            retVals.err_string = "Signature is too short";
+            return;
+        }
+
+        crypto::signature sig{};
+        memcpy(sig.c.data, buff, 32);
+        memcpy(sig.r.data, buff + 32, 32);
+
+        // Verification
+        std::vector<const crypto::public_key*> pkeys;
+        pkeys.push_back(&out_key);
+    
+        std::ostringstream ss{};
+        if (!(rct::scalarmultKey(rct::ki2rct(ki), rct::curveOrder()) == rct::identity())) {
+            retVals.did_error = true;
+            ss << "Key image out of validity domain: key image " << epee::string_tools::pod_to_hex(ki);
+            retVals.err_string = ss.str();
+            return;
+        }
+
+        if (!crypto::check_ring_signature((const crypto::hash&)ki, ki, pkeys, &sig)) {
+            retVals.did_error = true;
+            ss << "Signature failed for key image " << epee::string_tools::pod_to_hex(ki)
+                << ", signature " + epee::string_tools::pod_to_hex(sig)
+                << ", pubkey " + epee::string_tools::pod_to_hex(*pkeys[0]);
+            retVals.err_string = ss.str();
+            return;
+        }
+    }
+}

--- a/src/device_trezor.hpp
+++ b/src/device_trezor.hpp
@@ -1,0 +1,13 @@
+#ifndef MONERO_DEVICE_TREZOR_H
+#define MONERO_DEVICE_TREZOR_H
+
+#include "crypto.h"
+#include "tools__ret_vals.hpp"
+
+namespace device_trezor {
+    using namespace std;
+    
+    void check_computed_key_image(const crypto::public_key& out_key, const crypto::key_image &ki, const std::string signature, tools::RetVals_base& retVals) ;
+}
+
+#endif //MONERO_DEVICE_TREZOR_H

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -70,6 +70,7 @@ namespace serial_bridge
 		string amount;
 		string key_image;
 		rct::key mask;
+		crypto::key_derivation derivation;
 	};
 
 	struct Utxo: public UtxoBase {
@@ -205,6 +206,7 @@ namespace serial_bridge
 	string encrypt_payment_id(const string &args_string);
 	//
 	string extract_utxos(const string &args_string);
+	string verify_trezor_key_image(const string &args_string);
 }
 
 #endif /* serial_bridge_index_hpp */


### PR DESCRIPTION
## Summary
- Add a new method to verify the computed trezor key-image.
- Add derivation field for each found utxos. Trezor will not need to call `generate_key_derivation` before computing key-image

Build successfully

<img width="1244" alt="Screenshot 2025-03-26 at 05 14 11" src="https://github.com/user-attachments/assets/0a4bb64e-020b-4827-9154-d9e75dba1a48" />
